### PR TITLE
Fix predict.glmreg on single row data frames

### DIFF
--- a/R/predict.glmreg.R
+++ b/R/predict.glmreg.R
@@ -7,7 +7,7 @@ predict.glmreg <- function(object,newx,which=1:length(object$lambda), type=c("li
 if(!is.null(object$terms)){
  mf <- model.frame(delete.response(object$terms), newx, na.action = na.action, xlev = object$xlevels)
  newx <- model.matrix(delete.response(object$terms), mf, contrasts = object$contrasts)
- newx <- newx[,-1] ### remove the intercept
+ newx <- newx[, -1, drop = FALSE] ### remove the intercept
 }
 }
   b0=as.matrix(object$b0)


### PR DESCRIPTION
Calling predict.glmreg with a single row data frame fails because the
`[` operator drops the row dimension when removing the intercept. Fix
this by specifying `drop = FALSE`.